### PR TITLE
client server

### DIFF
--- a/Lesson-11/cmd/client/client.go
+++ b/Lesson-11/cmd/client/client.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+)
+
+func main() {
+	conn, err := net.Dial("tcp", "localhost:8000")
+	if err != nil {
+		fmt.Printf("Server connection error:%s", err)
+		return
+	}
+	defer conn.Close()
+
+	var message []byte
+	var needle string
+	reader := bufio.NewReader(os.Stdin)
+	serverReader := bufio.NewReader(conn)
+
+	for {
+		fmt.Print("Input search string (or 'quit' to exit): ")
+		needle, err = reader.ReadString('\n')
+		needle = strings.TrimSpace(needle) // Remove leading/trailing whitespace
+		fmt.Println("You entered ", needle)
+
+		if err != nil {
+			if err == io.EOF {
+				fmt.Printf("client closed the connection")
+			} else {
+				fmt.Printf("server error: %v\n", err)
+			}
+			break // Exit the loop on error
+		}
+
+		if needle == "quit" {
+			fmt.Println("Exiting the client.")
+			break
+		}
+
+		n, err := conn.Write([]byte(needle + "\n"))
+		if err != nil {
+			fmt.Printf("Error sending request:%s", err)
+			continue
+		}
+		fmt.Printf("%d bytes was sent to server\n", n)
+
+		message, err = serverReader.ReadBytes('\n')
+		if err != nil {
+			fmt.Printf("Error reading server response: %v\n", err)
+			break // Exit the loop on error
+		}
+		if len(message) > 0 {
+			fmt.Printf("Search results:%s\n", message)
+		}
+	}
+}

--- a/Lesson-11/cmd/server/server.go
+++ b/Lesson-11/cmd/server/server.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+	"thinknetica/Lesson-11/netsrv"
+	"thinknetica/Lesson-11/pkg/crawler"
+	"thinknetica/Lesson-11/pkg/crawler/spider"
+)
+
+const (
+	depth         = 2
+	serverAddress = "0.0.0.0:8000"
+)
+
+type ConnectionHandler func(net.Conn, []crawler.Document)
+
+func main() {
+	resources := []string{"https://golang-org.appspot.com/", "https://go.dev/"}
+	s := spider.New()
+	var scanResults []crawler.Document
+
+	fmt.Println("Start scanning resorces")
+	for _, url := range resources {
+		result, err := s.Scan(url, depth)
+		if err != nil {
+			fmt.Printf("Error due to scanning docs in %s resourse: %s", url, err)
+			continue
+		}
+		scanResults = append(scanResults, result...)
+	}
+
+	fmt.Println("Scanning is finished")
+	fmt.Println("Starting tcp server")
+
+	listener, err := net.Listen("tcp", serverAddress)
+	if err != nil {
+		fmt.Printf("Listener error:%s", err)
+		return
+	}
+
+	netListener := netsrv.NewServer(listener, scanResults)
+	go netListener.ListenAndServe() // or go netListener.ListenAndServe()
+
+	// Handle graceful shutdown
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	<-sigCh // Wait for a signal
+	fmt.Println("Shutting down the server...")
+
+	listener.Close() // Close any active connections
+
+	fmt.Println("Server is gracefully stopped")
+}

--- a/Lesson-11/netsrv/server.go
+++ b/Lesson-11/netsrv/server.go
@@ -1,0 +1,80 @@
+package netsrv
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"strings"
+	"thinknetica/Lesson-11/pkg/crawler"
+	"time"
+)
+
+type Server struct {
+	netListener net.Listener
+	scanResults []crawler.Document
+}
+
+func NewServer(netListener net.Listener, scanResults []crawler.Document) *Server {
+	return &Server{netListener: netListener, scanResults: scanResults}
+}
+
+func (s *Server) ListenAndServe() {
+	defer s.netListener.Close()
+	fmt.Println("Server is ready to accept client connections")
+	for {
+		conn, err := s.netListener.Accept()
+		if err != nil {
+			fmt.Printf("Accept connection error: %s\n", err)
+			continue
+		}
+
+		// Limit the number of concurrent connections (adjust as needed)
+		go s.handleClientRequest(conn)
+	}
+}
+
+func (s *Server) handleClientRequest(connection net.Conn) {
+	defer connection.Close()
+	var err error
+	var needle string
+	reader := bufio.NewReader(connection)
+
+	for {
+		needle, err = reader.ReadString('\n')
+		if err != nil {
+			fmt.Printf("Error reading client request: %s\n", err)
+			return
+		}
+
+		needle = strings.TrimSpace(needle)
+		searchResult := s.search(needle)
+		if len(searchResult) == 0 {
+			result := fmt.Sprintf(" No data found by: %s", needle)
+			_, err := connection.Write([]byte(result + "\n"))
+			if err != nil {
+				fmt.Printf("Error writing response to client: %s\n", err)
+			}
+			continue
+		}
+
+		result := strings.Join(searchResult, ",")
+		_, err = connection.Write([]byte(result + "\n"))
+
+		if err != nil {
+			fmt.Printf("Error writing response to client: %s\n", err)
+		}
+
+		// Reset the connection deadline on each successful request
+		connection.SetDeadline(time.Now().Add(time.Second * 60))
+	}
+}
+
+func (s *Server) search(needle string) []string {
+	var links []string
+	for _, value := range s.scanResults {
+		if strings.Contains(value.Title, needle) || strings.Contains(value.Body, needle) {
+			links = append(links, fmt.Sprintf("%s %s", value.Title, value.Body))
+		}
+	}
+	return links
+}

--- a/Lesson-11/pkg/crawler/crawler.go
+++ b/Lesson-11/pkg/crawler/crawler.go
@@ -1,0 +1,16 @@
+package crawler
+
+// Search bot. Scans web resources
+// Interface defines bot's contract
+type Interface interface {
+	Scan(url string, depth int) ([]Document, error)
+	BatchScan(urls []string, depth int, workers int) (<-chan Document, <-chan error)
+}
+
+// Document - Web document\
+type Document struct {
+	ID    int
+	URL   string
+	Title string
+	Body  string
+}

--- a/Lesson-11/pkg/crawler/membot/membot.go
+++ b/Lesson-11/pkg/crawler/membot/membot.go
@@ -1,0 +1,33 @@
+package membot
+
+import (
+	"thinknetica/Lesson-11/pkg/crawler"
+)
+
+// Service - имитация служба поискового робота.
+type Service struct{}
+
+// New - констрктор имитации службы поискового робота.
+func New() *Service {
+	s := Service{}
+	return &s
+}
+
+// Scan возвращает заранее подготовленный набор данных
+func (s *Service) Scan(url string, depth int) ([]crawler.Document, error) {
+
+	data := []crawler.Document{
+		{
+			ID:    0,
+			URL:   "https://go.dev/",
+			Title: "go-dev",
+		},
+		{
+			ID:    1,
+			URL:   "https://golang-org.appspot.com/",
+			Title: "golang org",
+		},
+	}
+
+	return data, nil
+}

--- a/Lesson-11/pkg/crawler/spider/spider.go
+++ b/Lesson-11/pkg/crawler/spider/spider.go
@@ -1,0 +1,124 @@
+// Package spider реализует сканер содержимого веб-сайтов.
+// Пакет позволяет получить список ссылок и заголовков страниц внутри веб-сайта по его URL.
+package spider
+
+import (
+	"net/http"
+	"strings"
+	"thinknetica/Lesson-11/pkg/crawler"
+
+	"golang.org/x/net/html"
+)
+
+// Service - служба поискового робота.
+type Service struct{}
+
+// New - констрктор службы поискового робота.
+func New() *Service {
+	s := Service{}
+	return &s
+}
+
+// Scan осуществляет рекурсивный обход ссылок сайта, указанного в URL,
+// с учётом глубины перехода по ссылкам, переданной в depth.
+func (s *Service) Scan(url string, depth int) (data []crawler.Document, err error) {
+	pages := make(map[string]string)
+
+	parse(url, url, depth, pages)
+
+	for url, title := range pages {
+		item := crawler.Document{
+			URL:   url,
+			Title: title,
+		}
+		data = append(data, item)
+	}
+
+	return data, nil
+}
+
+// parse рекурсивно обходит ссылки на странице, переданной в url.
+// Глубина рекурсии задаётся в depth.
+// Каждая найденная ссылка записывается в ассоциативный массив
+// data вместе с названием страницы.
+func parse(url, baseurl string, depth int, data map[string]string) error {
+	if depth == 0 {
+		return nil
+	}
+
+	response, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+
+	page, err := html.Parse(response.Body)
+	if err != nil {
+		return err
+	}
+
+	data[url] = pageTitle(page)
+
+	if depth == 1 {
+		return nil
+	}
+	links := pageLinks(nil, page)
+	for _, link := range links {
+		link = strings.TrimSuffix(link, "/")
+		// относительная ссылка
+		if strings.HasPrefix(link, "/") && len(link) > 1 {
+			link = baseurl + link
+		}
+		// ссылка уже отсканирована
+		if data[link] != "" {
+			continue
+		}
+		// ссылка содержит базовый url полностью
+		if strings.HasPrefix(link, baseurl) {
+			parse(link, baseurl, depth-1, data)
+		}
+	}
+
+	return nil
+}
+
+// pageTitle осуществляет рекурсивный обход HTML-страницы и возвращает значение элемента <tittle>.
+func pageTitle(n *html.Node) string {
+	var title string
+	if n.Type == html.ElementNode && n.Data == "title" && n.FirstChild != nil {
+		return n.FirstChild.Data
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		title = pageTitle(c)
+		if title != "" {
+			break
+		}
+	}
+	return title
+}
+
+// pageLinks рекурсивно сканирует узлы HTML-страницы и возвращает все найденные ссылки без дубликатов.
+func pageLinks(links []string, n *html.Node) []string {
+	if n.Type == html.ElementNode && n.Data == "a" {
+		for _, a := range n.Attr {
+			if a.Key == "href" {
+				if !sliceContains(links, a.Val) {
+					links = append(links, a.Val)
+				}
+			}
+		}
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		links = pageLinks(links, c)
+	}
+	return links
+}
+
+// sliceContains возвращает true если массив содержит переданное значение
+func sliceContains(slice []string, value string) bool {
+	for _, v := range slice {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}

--- a/Lesson-11/pkg/crawler/spider/spider_test.go
+++ b/Lesson-11/pkg/crawler/spider/spider_test.go
@@ -1,0 +1,1 @@
+package spider


### PR DESCRIPTION
Добавить в поисковик сетевую службу.

Нужно добавить в поисковик возможность принимать поисковые запросы с помощью telnet или специального клиента.

Задача №1

Удалить из поисковика артефакты из прошлых занятий: флаги командной строки, интерактивный режим(CLI), файлы и всё прочее, что не имеет отношения к текущему состоянию задачи.

Задача №2 

Создать отдельный пакет “netsrv”, который бы обеспечивал интерактивный режим работы с пользователем.

Служба “netsrv” должна принимать соединения на порту 8000 на всех сетевых интерфейсах системы.

Служба должна читать текстовые поисковые запросы и в ответ выдавать результаты поиска.

Задача №3

Разработать консольного клиента службы “netsrv”. Клиент должен работать в интерактивном режиме (запрос – ответ – запрос – и т.д.).